### PR TITLE
Update CMakeLists.txt to avoid building failure

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@ project(gpd_ros)
 find_package(catkin REQUIRED COMPONENTS cmake_modules eigen_conversions message_generation roscpp rospy sensor_msgs std_msgs)
 
 # PCL
-find_package(PCL REQUIRED)
+find_package(PCL 1.9 REQUIRED)
 include_directories(${PCL_INCLUDE_DIRS})
 link_directories(${PCL_LIBRARY_DIRS})
 add_definitions(${PCL_DEFINITIONS})


### PR DESCRIPTION
build may fail without any error message (by default it uses pcl 1.8 if other packages also requires pal)